### PR TITLE
revert node-pre-gyp install changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
     "example": "examples"
   },
   "scripts": {
-    "install": "npm install node-pre-gyp && ./node_modules/node-pre-gyp/bin/node-pre-gyp install --fallback-to-build",
-    "clean": "./node_modules/node-gyp/bin/node-gyp.js clean",
-    "configure": "./node_modules/node-gyp/bin/node-gyp.js configure",
+    "install": "node-pre-gyp install --fallback-to-build",
+    "clean": "node-gyp clean",
+    "configure": "node-gyp configure",
     "lint": "clang-format-lint src/*.cc src/*.h && eslint --ext .js .",
     "format": "clang-format-lint --fix src/*.cc src/*.h && eslint --fix --ext .js .",
-    "build": "npm run format && ./node_modules/node-gyp/bin/node-gyp.js rebuild",
-    "build:debug": "npm run format && ./node_modules/node-gyp/bin/node-gyp.js rebuild --debug",
-    "license:report": "mkdir -p report && ./node_modules/grunt/bin/grunt grunt-license-report",
+    "build": "npm run format && node-gyp rebuild",
+    "build:debug": "npm run format && node-gyp rebuild --debug",
+    "license:report": "mkdir -p report && grunt grunt-license-report",
     "license:addheader": "license-check-and-add",
     "test": "jest --verbose"
   },


### PR DESCRIPTION
There are 2 odd features of the package.json 1) the install script install node-pre-gyp again and 2) the scripts reach into node_modules. These seem to come from https://github.com/apache/pulsar-client-node/commit/a43cf73273fe7bb22535c06379910d1299fe2440

@SimonWoolf I don't quite understand the context of where this was failing to warrant the fix. If it was a local issue this could have been caused by a cache problem. 

We can never assume the details of a nested node_modules tree, if node-pre-gyp is deduped then it will not exist in node_modules. Perhaps you found it missing and thought that was the issue (where it ought to have been in the path still).

I'm reverting this because I believe it's messing up `npm ls` in realtime. Either way, the node-pre-gyp is redundant unless we publish tarballs of the pre-compiled binaries to s3. I would gladly create the tarball but we don't yet have a process for hosting pre-compiled binaries of ably forks.